### PR TITLE
Replace room index with room id in the return of LOCATION_OF

### DIFF
--- a/src/scripts/playback.js
+++ b/src/scripts/playback.js
@@ -89,8 +89,7 @@ function getEventAtLocation(data, location) {
  */
 function getLocationOfEvent(data, event) {
     const room = roomFromEvent(data, event);
-    const index = data.rooms.indexOf(room);
-    return { room: index, position: [...event.position] };
+    return { room: room.id, position: [...event.position] };
 }
 
 /**


### PR DESCRIPTION

With the test file ([test_room.html.zip](https://github.com/Ragzouken/bipsi/files/7726066/test_room.html.zip)), error appears when trying to `MOVE` to a location retrieved with `LOCATION_OF`.
It happens when you delete a room, id and index are not aligned anymore.

<img width="468" alt="Screenshot 2021-12-16 at 10 22 52" src="https://user-images.githubusercontent.com/1090485/146346193-d8fc847f-34f7-470d-8572-2c51736877ab.png">

Changed the return of LOCATION_OF so that it returns the id instead of the index


