### PR TITLE
Give plugins access to their event's id

### DIFF
--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -202,14 +202,14 @@ function filterJavascriptByPurposes(sourceCode, purposes) {
 
 function getRunnableJavascriptForOnePlugin(event, purposes) {
     const configFields = event.fields.filter((field) => field.key !== "plugin");
-    const configsJS = `const CONFIG = { fields: ${JSON.stringify(configFields)} };`;
+    const configsJS = `const CONFIG = { id: ${event.id}, fields: ${JSON.stringify(configFields)} };`;
     let pluginJS = FIELD(event, "plugin", "javascript");
     pluginJS = filterJavascriptByPurposes(pluginJS, purposes);
     pluginJS = `// PLUGIN CODE"\n${pluginJS}\n`;
     if (!pluginJS.replace(/\/\/[^\n]*\n|[\n\t ]/g, "")) {
         return "";
     }
-    return `(function () {\nconst EVENT_ID = ${event.id};\n// PLUGINS CONFIG\n${configsJS}\n${pluginJS}\n})();\n`;
+    return `(function () {\n// PLUGINS CONFIG\n${configsJS}\n${pluginJS}\n})();\n`;
 }
 
 class PaletteEditor {

--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -209,7 +209,7 @@ function getRunnableJavascriptForOnePlugin(event, purposes) {
     if (!pluginJS.replace(/\/\/[^\n]*\n|[\n\t ]/g, "")) {
         return "";
     }
-    return `(function () {\n// PLUGINS CONFIG\n${configsJS}\n${pluginJS}\n})();\n`;
+    return `(function () {\nconst EVENT_ID = ${event.id};\n// PLUGINS CONFIG\n${configsJS}\n${pluginJS}\n})();\n`;
 }
 
 class PaletteEditor {

--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -587,11 +587,12 @@ class EventEditor {
                 { key: "plugin", type: "javascript", data: js },
                 ...fieldsFromPluginCode(js),
             ];
+            const newEventId = nextEventId(EDITOR.stateManager.present);
 
             this.editor.createEvent(fields);
 
             // Run EDITOR code for the new plugin
-            const editorCode = getRunnableJavascriptForOnePlugin({ fields: fields }, [ "EDITOR" ]);
+            const editorCode = getRunnableJavascriptForOnePlugin({ id: newEventId, fields: fields }, [ "EDITOR" ]);
             new Function(editorCode)();
         });
 

--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -587,12 +587,12 @@ class EventEditor {
                 { key: "plugin", type: "javascript", data: js },
                 ...fieldsFromPluginCode(js),
             ];
-            const newEventId = nextEventId(EDITOR.stateManager.present);
+            const id = nextEventId(EDITOR.stateManager.present);
 
             this.editor.createEvent(fields);
 
             // Run EDITOR code for the new plugin
-            const editorCode = getRunnableJavascriptForOnePlugin({ id: newEventId, fields: fields }, [ "EDITOR" ]);
+            const editorCode = getRunnableJavascriptForOnePlugin({ id, fields }, [ "EDITOR" ]);
             new Function(editorCode)();
         });
 


### PR DESCRIPTION
First, I apologize for bringing an update to this editor plugin system so soon after launch.

-- The problem:
When submitting to bipsi-hacks, Sean pointed out that changes to an editor plugin's settings aren't applied until the page is refreshed.  This is because CONFIG is created at plugin setup, and doesn't update to match settings changes.

-- The solutions:
After consideration, I came up with two solutions.  This is one of them, and [here](https://github.com/Ragzouken/bipsi/pull/7) is the other.  The other is more complex, but I prefer it to this one as it's simpler for the plugin developer.

-- Specifics:
**This** solution provides the plugin with it's event id, forcing the plugin's editor code to "find" its event whenever it wants to read user-settings from it.  Meanwhile, the non-editor code still relies on CONFIG for the settings.

The **other** solution sets up CONFIG, for the editor code, to always have the latest settings.  In this way, the plugin's editor code can rely on CONFIG, just like the non-editor code does.