### PR TITLE
Editor plugin gets dynamic CONFIG

### DIFF
--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -219,8 +219,10 @@ function getRunnableJavascriptForOnePlugin(event, purposes) {
 }
 
 function refreshEditorPluginConfig(CONFIG) {
-    const event = window.findEventById(window.EDITOR.stateManager.present, CONFIG.id) || { fields: [] };
-    Object.setPrototypeOf(CONFIG, event);
+    const event = window.findEventById(window.EDITOR.stateManager.present, CONFIG.id);
+    if (event) {
+        Object.setPrototypeOf(CONFIG, event);
+    }
 }
 
 function refreshEditorPluginConfigs() {

--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -219,7 +219,7 @@ function getRunnableJavascriptForOnePlugin(event, purposes) {
 }
 
 function refreshEditorPluginConfig(CONFIG) {
-    const event = window.findEventById(window.EDITOR.stateManager.present, CONFIG.id);
+    const event = window.findEventById(window.EDITOR.stateManager.present, CONFIG.id) || { fields: [] };
     Object.setPrototypeOf(CONFIG, event);
 }
 

--- a/src/scripts/maker.js
+++ b/src/scripts/maker.js
@@ -352,6 +352,7 @@ maker.StateManager = class extends EventTarget {
         if (!this.canUndo) return;
         this.index -= 1;
         this.changed();
+        refreshEditorPluginConfigs();
     }
 
     /**
@@ -361,6 +362,7 @@ maker.StateManager = class extends EventTarget {
         if (!this.canRedo) return;
         this.index += 1;
         this.changed();
+        refreshEditorPluginConfigs();
     }
 };
 

--- a/src/scripts/maker.js
+++ b/src/scripts/maker.js
@@ -352,7 +352,6 @@ maker.StateManager = class extends EventTarget {
         if (!this.canUndo) return;
         this.index -= 1;
         this.changed();
-        refreshEditorPluginConfigs();
     }
 
     /**
@@ -362,7 +361,6 @@ maker.StateManager = class extends EventTarget {
         if (!this.canRedo) return;
         this.index += 1;
         this.changed();
-        refreshEditorPluginConfigs();
     }
 };
 


### PR DESCRIPTION
First, I apologize for bringing an update to this editor plugin system so soon after its launch.

### The problem:
When submitting to bipsi-hacks, Sean pointed out that changes to an editor plugin's settings aren't applied until the page is refreshed.  This is because CONFIG is created at plugin setup, and does NOT update to match settings changes.  This makes sense for playback, where the user doesn't change settings.  For edit-time, though, special consideration is needed to use the latest settings without a page refresh.

### The solution:
After consideration, I came up with the solution in this pull request.  This sets up CONFIG quite differently for editor code than for playback code.  For playback, CONFIG is the same as it always was.  For editor-time, CONFIG is an empty object with its prototype set to the plugin's _actual_ event.  This way it can always provide the latest settings, and its prototype can be re-set when the event object is replaced (for undo/redo).

### An alternative
If this solution isn't viable for some reason I have a minimal code-change alternate: simply give the plugin it's event id.  This isn't very nice, though.  The editor code must call `findEventById()` to grab the latest settings (a relatively heavy task).  Meanwhile, the playback code still uses CONFIG, meaning different code sections get the settings in different ways.
