### PR TITLE
Fix - both in-editor playback and export have no DOCTYPE

### DIFF
--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -2474,7 +2474,7 @@ class BipsiEditor extends EventTarget {
             clone.setAttribute("data-debug", "true");
         }
 
-        return clone.outerHTML;
+        return `<!DOCTYPE html>${clone.outerHTML}`;
     }
         
     async exportProject() {


### PR DESCRIPTION
The playback, both in the editor and when exporting to an html file, is run in "quirks mode" because of a missing "&lt;!DOCTYPE html&gt;" at the start.  This fixes that.