### PR TITLE
Fix - Pointed to event is always selected

### DIFF
--- a/src/scripts/editor/editor.js
+++ b/src/scripts/editor/editor.js
@@ -1411,7 +1411,7 @@ class BipsiEditor extends EventTarget {
             const { data, room } = this.getSelections();
             this.paletteSelectWindow.select.selectedIndex = data.palettes.indexOf(getPaletteById(data, room.palette));
             
-            this.selectedEventId = undefined;
+            this.selectPointedEvent();
             this.requestRedraw();
             this.eventEditor.refresh();
         });
@@ -1803,6 +1803,12 @@ class BipsiEditor extends EventTarget {
 
     requestRedraw() {
         this.requestedRedraw = true;
+    }
+
+    selectPointedEvent() {
+        const {x, y} = this.selectedEventCell;
+        this.selectedEventId = getEventsAt(this.getSelections().room.events, x, y)[0]?.id;
+        this.eventEditor.refresh();
     }
 
     update(dt) {

--- a/src/scripts/start.js
+++ b/src/scripts/start.js
@@ -13,6 +13,9 @@ async function startEditor(font) {
     // load bundle and enter editor mode
     await editor.loadBundle(bundle);
 
+    // Auto-select the pointed-to event (upper-left corner)
+    editor.selectPointedEvent();
+
     // unsaved changes warning
     window.addEventListener("beforeunload", (event) => {
         if (!editor.unsavedChanges) return;


### PR DESCRIPTION
It is sometimes jarring to have the event cursor be pointing to an event, but no event is selected for editing in the EventEditor, such as when first running the editor and going to "edit events" tab when there's an event in the upper-left corner of the first room.

This change refreshes the pointed-to event whenever the event cursor might change what it's pointing to.