### PR TITLE
Added a parameter to "SHOW_IMAGE" and "BipsiPlayback.showImage"…

### DIFF
--- a/src/scripts/blitsy.js
+++ b/src/scripts/blitsy.js
@@ -485,10 +485,24 @@ async function loadImage(src) {
     });
 }
 
-function loadImageLazy(src) {
+function loadImageLazy(src, waitForLoaded) {
     const image = document.createElement("img");
+    let result = image;
+    let promiseResolve = null;
+    if (waitForLoaded) {
+        result = new Promise(resolve => {
+            promiseResolve = resolve;
+        });
+    }
+    image.onload = () => {
+        if (promiseResolve) promiseResolve(image);
+    };
+    image.onerror = image.onload;
     image.src = src;
-    return image;
+    if (image.complete) {
+        image.onload();
+    }
+    return result;
 }
 
 /**

--- a/src/scripts/playback.js
+++ b/src/scripts/playback.js
@@ -472,8 +472,8 @@ class BipsiPlayback extends EventTarget {
         return url;
     } 
 
-    getFileImageElement(id) {
-        const image = this.imageElements.get(id) ?? loadImageLazy(this.getFileObjectURL(id));
+    async getFileImageElement(id, waitForLoaded) {
+        const image = this.imageElements.get(id) ?? await loadImageLazy(this.getFileObjectURL(id), waitForLoaded);
         this.imageElements.set(id, image);
         return image;
     }
@@ -749,9 +749,7 @@ class BipsiPlayback extends EventTarget {
         this.background = image;
     }
     
-    async showImage(imageID, fileIDs, layer, x, y) {
-        console.log(imageID, fileIDs, layer, x, y)
-
+    async showImage(imageID, fileIDs, layer, x, y, waitForLoaded=false) {
         if (typeof fileIDs === "string") {
             fileIDs = [fileIDs];
         }
@@ -759,7 +757,7 @@ class BipsiPlayback extends EventTarget {
         if (fileIDs.length === 0) {
             this.hideImage(imageID);
         } else {
-            const images = fileIDs.map((fileID) => this.getFileImageElement(fileID));
+            const images = await Promise.all(fileIDs.map((fileID) => this.getFileImageElement(fileID, waitForLoaded)));
             this.images.set(imageID, { image: images, layer, x, y });
         }
     }
@@ -981,8 +979,8 @@ const SCRIPTING_FUNCTIONS = {
         this.PLAYBACK.stopMusic();
     },
 
-    SHOW_IMAGE(id, files, layer, x, y) {
-        this.PLAYBACK.showImage(id, files, layer, x, y);
+    SHOW_IMAGE(id, files, layer, x, y, waitForLoaded=false) {
+        return this.PLAYBACK.showImage(id, files, layer, x, y, waitForLoaded);
     },
     HIDE_IMAGE(id) {
         this.PLAYBACK.hideImage(id);


### PR DESCRIPTION
… to wait until the image is fully loaded before using it.  Includes ability to call "await SHOW_IMAGE" to delay subsequent logic until the image is ACTUALLY shown.

NOTE - The new logic only takes into effect if actively enabled, otherwise it works as it always did.  There _are_ more awaits now, but by default they await on returned image objects, so have no appreciable effect.