### PR TITLE
catch uninitialized iterators

### DIFF
--- a/src/scripts/playback.js
+++ b/src/scripts/playback.js
@@ -828,7 +828,7 @@ async function standardEventTouch(playback, event) {
 function sample(playback, id, type, values) {
     let iterator = playback.variables.get(id);
 
-    if (iterator === undefined) {
+    if (!iterator || !iterator.next) {
         iterator = ITERATOR_FUNCS[type](values);
         playback.variables.set(id, iterator);
     }


### PR DESCRIPTION
in developing our game [A Secret Place](https://toreachpoise.itch.io/a-secret-place) we discovered an issue where some events that initially worked as expected would break with `SCRIPT ERROR: TypeError: iterator.next is not a function` when the player revisited an early room later in the game

this simple fix solved the issue for us, and seems unintrusive enough that I figured i'd suggest it here